### PR TITLE
Added maim+slop support, env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You do not need to specify the file name if you are going to use the script to t
 
 `puush -q myfile.png` - Upload an image and print the uploaded file URL to stdout without displaying desktop notifications.
 
-`env PUUSH_SCREENSHOT_DIR="$HOME/Pictures" PUUSH_DATE_FORMAT="%y-%m-%d_%H%M" puush -f` - Take a screenshot of the entire screen, store it in the 'Pictures' folder and use date format YY-MM-DD_HHMM for the filename.
+`env PUUSH_SCREENSHOT_DIR="$HOME/Pictures" PUUSH_DATE_FORMAT="%y-%m-%d_%H%M%S" puush -f` - Take a screenshot of the entire screen, store it in the '~/Pictures' folder and use date format yy-mm-dd_HHMMSS for the filename.
 
 ## Author & License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ puush4linux is a Linux client for the popular screenshot host [puush](http://puu
 
 **Arch Linux** users may install the [puush4linux package](https://aur.archlinux.org/packages/puush4linux/) from the AUR, packaged by [/u/some_random_guy_5345](https://www.reddit.com/user/some_random_guy_5345).
 
-1. Install dependencies: `bash`, `scrot`, `curl`, and `xclip`; optionally: `libnotify` and `optipng`.
+1. Install dependencies: `bash`, `scrot`, `curl`, and `xclip`; optionally: `libnotify`, `optipng`, `xdotool`, [maim](https://github.com/naelstrof/maim) and [slop](https://github.com/naelstrof/slop). If `maim` and `slop` are installed, maim is preferred over scrot when taking screenshots.
 2. Download the puush file and copy it to `/usr/bin`.
 3. Run `puush -l` in your terminal and enter your user name and password to log in.
 4. Set up shortcuts in your window manager/desktop environment to your liking.
@@ -31,17 +31,27 @@ You do not need to specify the file name if you are going to use the script to t
 
 `-f` - Take a screenshot of the entire screen and upload it.
 
-`-w` - Take a screenshot of the active window and upload it.
+`-w` - Take a screenshot of the active window and upload it. If using maim, `xdotool` is required.
 
 `-l` - (Re-)log in to puush with your username and password.
 
 `-b` - Don't optimize images with optipng; only applies when using `-afw` (Automatically disabled if optipng isn't found on the system)
+
+`-s` - Use scrot even if maim and slop are installed.
+
+### Optional environment variables
+
+`PUUSH_SCREENSHOT_DIR` - Directory in which to save screenshots. If defined, screenshots are not deleted after uploading. If not defined, "/tmp" is used.
+
+`PUUSH_DATE_FORMAT` - Date format for file name. See `man date` for information. Default is "%d-%m-%Y-%H%M%S".
 
 ### Examples
 
 `puush -c -a` - Take a screenshot of an area, upload it and put the link into the clipboard. (Equivalent to Ctrl+Shift+4 on Windows systems.)
 
 `puush -q myfile.png` - Upload an image and print the uploaded file URL to stdout without displaying desktop notifications.
+
+`env PUUSH_SCREENSHOT_DIR="$HOME/Pictures" PUUSH_DATE_FORMAT="%y-%m-%d_%H%M" puush -f` - Take a screenshot of the entire screen, store it in the 'Pictures' folder and use date format YY-MM-DD_HHMM for the filename.
 
 ## Author & License
 

--- a/puush
+++ b/puush
@@ -13,6 +13,18 @@ OPTIND=1
 PUUSH_QUIET=0 # Whether notifications via libnotify will be shown (default) or hidden.
 PUUSH_CLIP=0 # Whether the script will output to stdout (default) or the X clipboard.
 OPTIPNG_IMAGE=1 # Whether it will run a screenshotted image through optipng before uploading.
+PUUSH_XDOTOOL=0 # Needs to be installed for -w option when using maim.
+
+if type maim &> /dev/null && type slop &> /dev/null; then
+	# Prefer slop + maim over scrot if they are installed
+	PUUSH_USE_SCROT=0
+	if type xdotool &> /dev/null; then
+		# If xdotool is not installed, produce an error when using -w with maim
+		PUUSH_XDOTOOL=1
+	fi
+else
+	PUUSH_USE_SCROT=1
+fi
 
 sleep 0.2 # Fix for rogue WMs/DEs.
 
@@ -28,6 +40,7 @@ function show_help {
 	echo " -w 		Take a screenshot of the active window and upload it."
 	echo " -l 		Log in to puush.me and save the API key."
 	echo " -b 		Don't run the image through optipng, only applies with -afw"
+	echo " -s 		Use scrot even if maim and slop are installed."
 	echo "Examples: "
 	echo " puush -c -a 	Take an area screenshot, upload it and put the URL into clipboard"
 	echo "		(emulates Ctrl+Shift+4 from the official version)"
@@ -41,7 +54,7 @@ notify() {
 	fi
 }
 
-while getopts "h?qchafwlb" opt; do
+while getopts "h?qchafwlbs" opt; do
     case "$opt" in
     h|\?)
         show_help
@@ -61,8 +74,27 @@ while getopts "h?qchafwlb" opt; do
 		;;
 	b)  OPTIPNG_IMAGE=0
 		;;
+	s)  PUUSH_USE_SCROT=1
+		;;
     esac
 done
+
+# Optional env variables:
+#   PUUSH_SCREENSHOT_DIR # If defined, saves screenshots here
+#     Example: env PUUSH_SCREENSHOT_DIR="$HOME/Pictures/puush"
+#   PUUSH_DATE_FORMAT # If defined, will be used instead of the default date format
+#     Example (for yyyy-mm-dd-HHMMSS): env PUUSH_DATE_FORMAT="%Y-%m-%d-%H%M%S"
+#     See 'man date' for more information
+
+# If PUUSH_SCREENSHOT_DIR is undefined, use /tmp
+if [[ -z $PUUSH_SCREENSHOT_DIR || ! -d $PUUSH_SCREENSHOT_DIR ]]; then
+	PUUSH_SCREENSHOT_DIR="/tmp"
+fi
+
+# If PUUSH_DATE_FORMAT is undefined, use dd-mm-yyyy-HHMMSS (the old default value)
+if [[ -z $PUUSH_DATE_FORMAT ]]; then
+	PUUSH_DATE_FORMAT="%d-%m-%Y-%H%M%S"
+fi
 
 shift $((OPTIND-1))
 [ "$1" = "--" ] && shift
@@ -119,15 +151,29 @@ fi
 
 # Generate a file name
 if [[ -z $PUUSH_FILE ]]; then
-	PUUSH_FILE="/tmp/ss-$(date '+%d-%m-%Y-%H%M%S').png"
+	PUUSH_FILE="$PUUSH_SCREENSHOT_DIR/ss-$(date +$PUUSH_DATE_FORMAT).png"
 fi
 
 # Take the screenshot if necessary.
-case $PUUSH_MODE in
-	a) scrot -b -q 90 -s "$PUUSH_FILE";;
-	w) scrot -b -q 90 -u "$PUUSH_FILE";;
-	f) scrot -b -q 90 "$PUUSH_FILE";;
-esac
+if [[ "$PUUSH_USE_SCROT" == 1 ]]; then
+	# Take the screenshot using scrot
+	case $PUUSH_MODE in
+		a) scrot -b -q 90 -s "$PUUSH_FILE";;
+		w) scrot -b -q 90 -u "$PUUSH_FILE";;
+		f) scrot -b -q 90 "$PUUSH_FILE";;
+	esac
+else
+	# Take the screenshot using maim + slop
+	case $PUUSH_MODE in
+		a) maim -s "$PUUSH_FILE";;
+		w) if [[ "$PUUSH_XDOTOOL" == 1 ]]; then
+			maim -i $(xdotool getactivewindow) "$PUUSH_FILE"
+		else
+			notify "xdotool not installed, can't use -w with maim; use -s to use scrot instead."
+		fi;;
+		f) maim "$PUUSH_FILE";;
+	esac
+fi
 
 # optimize image using optipng
 if [[ -n "$PUUSH_MODE" && $OPTIPNG_IMAGE = 1 ]]; then
@@ -179,6 +225,6 @@ fi
 
 # Clean up the temporary screenshot file if it was temporary.
 
-if [[ ! -z $PUUSH_MODE ]]; then
+if [[ ! -z $PUUSH_MODE && $PUUSH_SCREENSHOT_DIR == "/tmp" ]]; then
 	rm "$PUUSH_FILE"
 fi


### PR DESCRIPTION
If maim and slop are installed, use them instead of scrot. Scrot can still be forced with the -s switch. Also added support for two optional env variables, PUUSH_SCREENSHOT_DIR and PUUSH_DATE_FORMAT.

maim+slop support is pretty straightforward, they're automatically detected and preferred over scrot. This shouldn't affect old functionality at all. Furthermore, optipng doesn't have nearly as huge of an impact on screenshots taken with maim compared to scrot - it only makes a ~20% difference. The only caveat is that `-w` requires xdotool, but slop's window selection tool make up for that if you ask me.

PUUSH_SCREENSHOT_DIR can be specified if the user wants to store screenshots in a directory, such as a 'Pictures' folder. PUUSH_DATE_FORMAT is a unix date format string that can override the default one. This one was important for me personally, since I wanted to be able to sort my screenshots by date. Both are features on the Windows puush client, so it should make sense to add them.

I apologise for adding two different features in one pull request, but this repository doesn't seem to be updated that often so I figured it'd be less of a hassle to merge both changes in one pr. The readme has been updated to reflect the changes.

I made a pr to the base repo before I noticed that it hadn't been updated for ages, so I forked this fork and added my changes there.
